### PR TITLE
Fix candidate success message condition

### DIFF
--- a/candidate.php
+++ b/candidate.php
@@ -17,8 +17,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         if ($full_name && $email && $cover_letter && $vacancy_id) {
             $result = createCandidateApplication($full_name, $email, $cover_letter, $vacancy_id);
             if ($result) {
+                $newCandidate = isset($result['candidate']['generated_password']) && $result['candidate']['generated_password'];
                 $message = "<p class='alert alert-success'>Ваша заявка отправлена. " .
-                           ($result['candidate']['generated_password'] ? "Ваши учётные данные отправлены на email." : "Вы уже зарегистрированы – используйте свои учётные данные.") .
+                           ($newCandidate ? "Ваши учётные данные отправлены на email." : "Вы уже зарегистрированы – используйте свои учётные данные.") .
                            "</p>";
             } else {
                 $message = "<p class='alert alert-danger'>Ошибка при отправке заявки.</p>";


### PR DESCRIPTION
## Summary
- fix undefined index by checking `generated_password` before using it

## Testing
- `php -l candidate.php`
- `php -l functions.php`


------
https://chatgpt.com/codex/tasks/task_e_68405b603a74832c80c27527f134537a